### PR TITLE
Use Parcelable instead of Serializable for intent data

### DIFF
--- a/app/src/main/java/co/adrianblan/cheddar/Comment.java
+++ b/app/src/main/java/co/adrianblan/cheddar/Comment.java
@@ -1,11 +1,12 @@
 package co.adrianblan.cheddar;
 
-import java.io.Serializable;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 /**
  * Created by Adrian on 2015-07-30.
  */
-public class Comment implements Serializable {
+public class Comment implements Parcelable {
     private String by;
     private String body;
     private String time;
@@ -79,4 +80,42 @@ public class Comment implements Serializable {
     public void setHiddenChildren(int hiddenChildren) {
         this.hiddenChildren = hiddenChildren;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.by);
+        dest.writeString(this.body);
+        dest.writeString(this.time);
+        dest.writeByte(hideChildren ? (byte) 1 : (byte) 0);
+        dest.writeByte(isHidden ? (byte) 1 : (byte) 0);
+        dest.writeByte(toBeHidden ? (byte) 1 : (byte) 0);
+        dest.writeInt(this.hiddenChildren);
+        dest.writeInt(this.hierarchy);
+    }
+
+    protected Comment(Parcel in) {
+        this.by = in.readString();
+        this.body = in.readString();
+        this.time = in.readString();
+        this.hideChildren = in.readByte() != 0;
+        this.isHidden = in.readByte() != 0;
+        this.toBeHidden = in.readByte() != 0;
+        this.hiddenChildren = in.readInt();
+        this.hierarchy = in.readInt();
+    }
+
+    public static final Creator<Comment> CREATOR = new Creator<Comment>() {
+        public Comment createFromParcel(Parcel source) {
+            return new Comment(source);
+        }
+
+        public Comment[] newArray(int size) {
+            return new Comment[size];
+        }
+    };
 }

--- a/app/src/main/java/co/adrianblan/cheddar/CommentActivity.java
+++ b/app/src/main/java/co/adrianblan/cheddar/CommentActivity.java
@@ -76,13 +76,13 @@ public class CommentActivity extends AppCompatActivity implements ObservableScro
 
         if(savedInstanceState == null){
             Bundle b = getIntent().getExtras();
-            feedItem = (FeedItem) b.getSerializable("feedItem");
+            feedItem = b.getParcelable("feedItem");
             commentAdapter = new CommentAdapter(feedItem, this);
         } else {
 
             // We retrieve the saved items
-            feedItem = (FeedItem) savedInstanceState.getSerializable("feedItem");
-            ArrayList<Comment> comments = (ArrayList<Comment>) savedInstanceState.getSerializable("comments");
+            feedItem = savedInstanceState.getParcelable("feedItem");
+            ArrayList<Comment> comments = savedInstanceState.getParcelableArrayList("comments");
             commentAdapter = new CommentAdapter(comments, feedItem, this);
         }
 
@@ -156,7 +156,7 @@ public class CommentActivity extends AppCompatActivity implements ObservableScro
                 public void onClick(View v) {
                     Intent intent = new Intent(v.getContext(), WebViewActivity.class);
                     Bundle bundle = new Bundle();
-                    bundle.putSerializable("feedItem", feedItem);
+                    bundle.putParcelable("feedItem", feedItem);
                     intent.putExtra("thumbnail", thumbnail);
                     intent.putExtras(bundle);
                     startActivity(intent);
@@ -464,7 +464,7 @@ public class CommentActivity extends AppCompatActivity implements ObservableScro
         else if(id == R.id.menu_webview){
             Intent intent = new Intent(this, WebViewActivity.class);
             Bundle b = new Bundle();
-            b.putSerializable("feedItem", feedItem);
+            b.putParcelable("feedItem", feedItem);
             intent.putExtra("thumbnail", thumbnail);
             intent.putExtras(b);
             startActivity(intent);
@@ -510,7 +510,7 @@ public class CommentActivity extends AppCompatActivity implements ObservableScro
         super.onSaveInstanceState(savedInstanceState);
 
         // Save data
-        savedInstanceState.putSerializable("feedItem", feedItem);
-        savedInstanceState.putSerializable("comments", commentAdapter.getComments());
+        savedInstanceState.putParcelable("feedItem", feedItem);
+        savedInstanceState.putParcelableArrayList("comments", commentAdapter.getComments());
     }
 }

--- a/app/src/main/java/co/adrianblan/cheddar/FeedAdapter.java
+++ b/app/src/main/java/co/adrianblan/cheddar/FeedAdapter.java
@@ -150,7 +150,7 @@ public class FeedAdapter extends BaseAdapter {
 
                 Intent intent = new Intent(v.getContext(), CommentActivity.class);
                 Bundle b = new Bundle();
-                b.putSerializable("feedItem", item);
+                b.putParcelable("feedItem", item);
                 intent.putExtra("thumbnail", thumbnail);
                 intent.putExtras(b);
                 context.startActivity(intent);
@@ -181,7 +181,7 @@ public class FeedAdapter extends BaseAdapter {
 
                     Intent intent = new Intent(v.getContext(), WebViewActivity.class);
                     Bundle b = new Bundle();
-                    b.putSerializable("feedItem", item);
+                    b.putParcelable("feedItem", item);
                     intent.putExtra("thumbnail", thumbnail);
                     intent.putExtras(b);
                     context.startActivity(intent);

--- a/app/src/main/java/co/adrianblan/cheddar/FeedFragment.java
+++ b/app/src/main/java/co/adrianblan/cheddar/FeedFragment.java
@@ -100,7 +100,7 @@ public class FeedFragment extends Fragment implements ObservableScrollViewCallba
             feedAdapter = new FeedAdapter(getActivity());
         } else {
             // Restore saved data
-            ArrayList<FeedItem> feedItems = (ArrayList<FeedItem>) savedInstanceState.getSerializable("feedItems");
+            ArrayList<FeedItem> feedItems = savedInstanceState.getParcelableArrayList("feedItems");
             feedAdapter = new FeedAdapter(feedItems, getActivity());
         }
 
@@ -572,6 +572,6 @@ public class FeedFragment extends Fragment implements ObservableScrollViewCallba
         super.onSaveInstanceState(savedInstanceState);
 
         // Save data
-        savedInstanceState.putSerializable("feedItems", feedAdapter.getFeedItems());
+        savedInstanceState.putParcelableArrayList("feedItems", feedAdapter.getFeedItems());
     }
 }

--- a/app/src/main/java/co/adrianblan/cheddar/FeedItem.java
+++ b/app/src/main/java/co/adrianblan/cheddar/FeedItem.java
@@ -2,13 +2,13 @@ package co.adrianblan.cheddar;
 
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
-
-import java.io.Serializable;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 /**
  * Created by Adrian on 2015-07-25.
  */
-public class FeedItem implements Serializable {
+public class FeedItem implements Parcelable {
 
     // For info on these variables, check out the Hacker News FireBase API
     private Long submissionId;
@@ -146,4 +146,48 @@ public class FeedItem implements Serializable {
     public void setColor(int color) {
         this.color = color;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeValue(this.submissionId);
+        dest.writeString(this.title);
+        dest.writeString(this.by);
+        dest.writeString(this.text);
+        dest.writeLong(this.score);
+        dest.writeLong(this.descendants);
+        dest.writeString(this.time);
+        dest.writeString(this.shortUrl);
+        dest.writeString(this.longUrl);
+        dest.writeString(this.letter);
+        dest.writeInt(this.color);
+    }
+
+    protected FeedItem(Parcel in) {
+        this.submissionId = (Long) in.readValue(Long.class.getClassLoader());
+        this.title = in.readString();
+        this.by = in.readString();
+        this.text = in.readString();
+        this.score = in.readLong();
+        this.descendants = in.readLong();
+        this.time = in.readString();
+        this.shortUrl = in.readString();
+        this.longUrl = in.readString();
+        this.letter = in.readString();
+        this.color = in.readInt();
+    }
+
+    public static final Creator<FeedItem> CREATOR = new Creator<FeedItem>() {
+        public FeedItem createFromParcel(Parcel source) {
+            return new FeedItem(source);
+        }
+
+        public FeedItem[] newArray(int size) {
+            return new FeedItem[size];
+        }
+    };
 }

--- a/app/src/main/java/co/adrianblan/cheddar/WebViewActivity.java
+++ b/app/src/main/java/co/adrianblan/cheddar/WebViewActivity.java
@@ -32,7 +32,7 @@ public class WebViewActivity extends AppCompatActivity {
         setContentView(R.layout.activity_webview);
 
         Bundle b = getIntent().getExtras();
-        feedItem = (FeedItem) b.getSerializable("feedItem");
+        feedItem = b.getParcelable("feedItem");
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar_webview);
         setSupportActionBar(toolbar);
@@ -162,7 +162,7 @@ public class WebViewActivity extends AppCompatActivity {
             // Go to the comments
             Intent intent = new Intent(getApplicationContext(), CommentActivity.class);
             Bundle b = new Bundle();
-            b.putSerializable("feedItem", feedItem);
+            b.putParcelable("feedItem", feedItem);
             intent.putExtra("thumbnail", thumbnail);
             intent.putExtras(b);
             startActivity(intent);

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
`Parcelables` on Android generally have 10x the performance of `Serializables`.  Alternatively we can use something like [Parcler](http://parceler.org/) to reduce boilerplate parcelable code. 
